### PR TITLE
Adding multiline-support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -31,6 +31,8 @@ A typical INI file might look like this:
   ; some comment on section1
   var1 = foo
   var2 = doodle
+  var3 = "multiline
+  also possible"
  
   [section2]
 
@@ -38,12 +40,13 @@ A typical INI file might look like this:
   var1 = baz
   var2 = shoodle
 
+
 ==== Format
 
 This describes the elements of the INI file format:
 
 * *Sections*: Section declarations start with '[' and end with ']' as in [section1] and [section2] above. And sections start with section declarations.
-* *Parameters*: The "var1 = foo" above is an example of a parameter (also known as an item). Parameters are made up of a key ('var1'), equals sign ('='), and a value ('foo').
+* *Parameters*: The "var1 = foo" above is an example of a parameter (also known as an item). Parameters are made up of a key ('var1'), equals sign ('='), and a value ('foo'). Multiline is support if value of parameter is enclosed by ".
 * *Comments*: All the lines starting with a ';' are assumed to be comments, and are ignored.
 
 ==== Differences
@@ -64,7 +67,7 @@ This package supports the standard INI file format described in the *Format*
 section above. The following differences are also supported:
 
 * *Comments*: The comment character can be specified when an +IniFile+ is created. The comment character must be the first non-whitespace character on a line.
-* *Backslashes*: Backslashes are not supported by this package.
+* *Backslashes*: Backslashes are not supported by this package. But multilines are. Enclose the param's value by ".
 * <b>Duplicate parameters</b>: Duplicate parameters are allowed in a single section. The last parameter value is the one that will be stored in the +IniFile+.
 * <b>Duplicate sections</b>: Duplicate sections will be merged. Parameters duplicated between to the two sections follow the duplicate parameters rule above.
 * *Parameters*: The parameter separator character can be specified when an +IniFile+ is created.

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -47,11 +47,11 @@ class IniFile
 
     @rgxp_comment = %r/\A\s*\z|\A\s*[#{@comment}]/
     @rgxp_section = %r/\A\s*\[([^\]]+)\]/o
-    @rgxp_param   = %r/\A([^#{@param}]+)#{@param}(.*)\z/
+    @rgxp_param   = %r/\A([^#{@param}]+)#{@param}\s*"?([^"]*)"?\z/
 
-    @rgxp_multiline_start = %r/\A(?<param>[^#{@param}]+)#{@param}\s*?"+(?<value>.*)\z/
-    @rgxp_multiline_value = %r/\A(?<value>.*[^"])\z/
-    @rgxp_multiline_end   = %r/\A(?<value>.*)"\z/
+    @rgxp_multiline_start = %r/\A(?<param>[^#{@param}]+)#{@param}\s*"+(?<value>[^"]*)?\z/
+    @rgxp_multiline_value = %r/\A(?<value>[^"]*)\z/
+    @rgxp_multiline_end   = %r/\A(?<value>[^"]*)"\z/
 
     parse
   end

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -49,9 +49,9 @@ class IniFile
     @rgxp_section = %r/\A\s*\[([^\]]+)\]/o
     @rgxp_param   = %r/\A([^#{@param}]+)#{@param}(.*)\z/
 
-    @rgxp_multiline_start = %r/\A(?<param>[^#{@param}]+)#{@param}\s*"(?<value>.*)\z/
-    @rgxp_multiline_value = %r/\A(?<value>[^"]*)\z/
-    @rgxp_multiline_end   = %r/\A(?<value>[^"]*)"\z/
+    @rgxp_multiline_start = %r/\A(?<param>[^#{@param}]+)#{@param}\s*?"+(?<value>.*)\z/
+    @rgxp_multiline_value = %r/\A(?<value>.*[^"])\z/
+    @rgxp_multiline_end   = %r/\A(?<value>.*)"\z/
 
     parse
   end
@@ -297,14 +297,14 @@ class IniFile
           tmp_param = $~[:param].strip
           tmp_value = $~[:value] + "\n"
           
-       elsif line =~ @rgxp_multiline_value && tmp_param != ""  then
-
-          tmp_value += $~[:value] + "\n"
-
         elsif line =~ @rgxp_multiline_end && tmp_param != "" then
 
           section[tmp_param] = tmp_value + $~[:value]
-          tmp_value, tmp_param = ""
+          tmp_value, tmp_param = "", ""
+
+        elsif line =~ @rgxp_multiline_value && tmp_param != ""  then
+
+          tmp_value += $~[:value] + "\n"
 
         # ignore blank lines and comment lines
         elsif line =~ @rgxp_comment then
@@ -319,7 +319,7 @@ class IniFile
         # otherwise we have a parameter
         elsif line =~ @rgxp_param then
 
-         begin
+          begin
             section[$1.strip] = $2.strip
           rescue NoMethodError
             raise Error, "parameter encountered before first section"
@@ -330,6 +330,7 @@ class IniFile
         end
       end  # while
     end  # File.open
+
   end
 
 end  # class IniFile

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -292,16 +292,23 @@ class IniFile
       while line = f.gets
         line = line.chomp
 
+        # mutline start
+        # create tmp variables to indicate that a multine has started
+        # and the next lines of the ini file will be checked
+        # against the other mutline rgxps.
         if line =~ @rgxp_multiline_start then
 
           tmp_param = $~[:param].strip
           tmp_value = $~[:value] + "\n"
           
+        # the mutline end-delimiter is found
+        # clear the tmp vars and add the param / value pair to the section
         elsif line =~ @rgxp_multiline_end && tmp_param != "" then
 
           section[tmp_param] = tmp_value + $~[:value]
           tmp_value, tmp_param = "", ""
 
+        # anything else between multiline start and end
         elsif line =~ @rgxp_multiline_value && tmp_param != ""  then
 
           tmp_value += $~[:value] + "\n"
@@ -326,7 +333,7 @@ class IniFile
           end
 
         else
-          raise Error, "could not parse line '#{tmp_param}"
+          raise Error, "could not parse line '#{line}"
         end
       end  # while
     end  # File.open

--- a/test/data/good.ini
+++ b/test/data/good.ini
@@ -3,7 +3,9 @@ one = 1
 two = 2
 
 [section_two]
-three =         3    
+three =         3
+multi = "multiline
+support"
 
 ; comments should be ignored
 [section three]

--- a/test/data/multiline.ini
+++ b/test/data/multiline.ini
@@ -9,7 +9,7 @@ three =         3
 [section_three]
 three   = "hello
 multiline"
-other = stuff
+other = "stuff"
 
 [section_four]
 four   = "hello

--- a/test/data/multiline.ini
+++ b/test/data/multiline.ini
@@ -1,0 +1,17 @@
+[section_one]
+one = 1
+two = 2
+
+[section_two]
+three =         3
+
+; comments should be ignored
+[section_three]
+three   = "hello
+multiline"
+other = stuff
+
+[section_four]
+four   = "hello
+multiple
+multilines"

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -6,7 +6,7 @@ begin
   require 'inifile'
 rescue LoadError
   require 'rubygems'
-  require 'inifile'
+  require '/home/melkon/rb/inifile/lib/inifile'
 end
 
 require 'fileutils'
@@ -329,6 +329,20 @@ class TestIniFile < Test::Unit::TestCase
     ini_file["foo"] = {:one => :two}
     ini_file[:foo] = {}
     assert_equal ini_file["foo"], {}
+  end
+
+  def test_multiline_parsing
+    
+    ini_file = IniFile.load('test/data/multiline.ini')
+    
+    multiline = ini_file['section_two']
+    expected = {"four" => "hello\nmultiline"}
+    assert_equal expected, multiline
+
+    multiple = ini_file['section_three']
+    expected = {"three" => "hello\nmultiple\nmultilines"}
+    assert_equal expected, multiple
+
   end
 end
 

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -6,7 +6,7 @@ begin
   require 'inifile'
 rescue LoadError
   require 'rubygems'
-  require '/home/melkon/rb/inifile/lib/inifile'
+  require 'inifile'
 end
 
 require 'fileutils'
@@ -335,12 +335,12 @@ class TestIniFile < Test::Unit::TestCase
     
     ini_file = IniFile.load('test/data/multiline.ini')
     
-    multiline = ini_file['section_two']
-    expected = {"four" => "hello\nmultiline"}
+    multiline = ini_file['section_three']
+    expected = {"three" => "hello\nmultiline", "other" => "stuff"}
     assert_equal expected, multiline
 
-    multiple = ini_file['section_three']
-    expected = {"three" => "hello\nmultiple\nmultilines"}
+    multiple = ini_file['section_four']
+    expected = {"four" => "hello\nmultiple\nmultilines"}
     assert_equal expected, multiple
 
   end

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -22,6 +22,7 @@ class TestIniFile < Test::Unit::TestCase
       ['section_one', 'one', '1'],
       ['section_one', 'two', '2'],
       ['section_two', 'three', '3'],
+      ['section_two', 'multi', "multiline\nsupport"],
       ['section three', 'four', '4'],
       ['section three', 'five', '5'],
       ['section three', 'six', '6'],
@@ -135,7 +136,7 @@ class TestIniFile < Test::Unit::TestCase
     IniFile.new('temp.ini').each {|*args| ary << args}
     assert_equal [], ary
   end
-
+  
   def test_each_section
     expected = [
       'section_one', 'section_two', 'section three',
@@ -192,7 +193,7 @@ class TestIniFile < Test::Unit::TestCase
     }
     assert_equal expected, @ini_file[:section_one]
 
-    expected = {'three' => '3'}
+    expected = {'three' => '3', 'multi' => "multiline\nsupport"}
     assert_equal expected, @ini_file['section_two']
 
     expected = {


### PR DESCRIPTION
Hello guys,

I stumbled upon inifile during my quest for a good ruby-implementation of 

http://www.php.net/manual/en/function.parse-ini-file.php

Since it doesn't support multine-line values (what I do need), I forked the project and added this feature myself. It's now working (though not fully functional, I'm missing the possibility to devaluate " with \ inside a multiline-value). I also added / changed new or existing testcases to test the new feature.

Note: I had to exchange the case-statement in the parse-function with ifs to be able to combine multiple conditions for a single if with AND.

I'd like to know if there's any interest in merging my changes back to the main repository. 

Kind Regards,
André Gawron
