### PR TITLE
Default section name + liberal param value options

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -12,7 +12,7 @@ class IniFile
 
   # :stopdoc:
   class Error < StandardError; end
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
   # :startdoc:
 
   #


### PR DESCRIPTION
two quick new feature hacks if they seem worthwhile:

A default option to allow reading ini files which don't contain multiple sections. The value provides the name of a default section:
ini = IniFile.new('config.ini', :default => 'default')

A liberal option to allow parsing parameters values which contain quotes within the value, e.g.:

paramname = CONSTANT_VALUE "quoted/string"

ini = IniFile.new('config.ini', :liberal => true)
