### PR TITLE
Ability to parse unescaped values

### DIFF
--- a/test/data/no_escaping.ini
+++ b/test/data/no_escaping.ini
@@ -1,0 +1,3 @@
+[unescaped_param]
+one=key=value
+two=key\=value

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -9,7 +9,7 @@ require 'test/unit'
 class TestIniFile < Test::Unit::TestCase
 
   def setup
-    @ini_file = IniFile.new(:filename => 'test/data/good.ini')
+#    @ini_file = IniFile.new(:filename => 'test/data/good.ini')
     @contents = [
       ['section_one', 'one', '1'],
       ['section_one', 'two', '2'],
@@ -53,6 +53,13 @@ class TestIniFile < Test::Unit::TestCase
 
     # make sure we error out on files with bad lines
     assert_raise(IniFile::Error) {IniFile.load 'test/data/bad_1.ini'}
+
+    # make sure we error out on sloppy escaping
+    assert_raise(IniFile::Error) {IniFile.load 'test/data/no_escaping.ini'}
+
+    ini_file = IniFile.load 'test/data/no_escaping.ini', :escape => false
+    assert_instance_of IniFile, ini_file
+
   end
 
   def test_clone
@@ -487,6 +494,12 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal %w[nonce], ini_file.sections
     assert_equal '1', ini_file['nonce']['one']
     assert_equal '2', ini_file['nonce']['two']
+  end
+
+  def test_unescaped_items
+    ini_file = IniFile.load('test/data/no_escaping.ini', :escape => false)
+
+    assert_equal 'key\=value', ini_file['unescaped_param']['two']
   end
 end
 

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -9,7 +9,7 @@ require 'test/unit'
 class TestIniFile < Test::Unit::TestCase
 
   def setup
-#    @ini_file = IniFile.new(:filename => 'test/data/good.ini')
+    @ini_file = IniFile.new(:filename => 'test/data/good.ini')
     @contents = [
       ['section_one', 'one', '1'],
       ['section_one', 'two', '2'],


### PR DESCRIPTION
It would be useful to be able to parse files which do not escape their values, just like they can be created with `escape => false`. For instance Picasa does not escape values,and writes files containing lines such as:
`key=this=that`
When setting `escape => false`, it should be respected for reading as well as writing.
