### PR TITLE
Allow parameter to appear in values if escaped

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -525,6 +525,7 @@ private
       when '\r';   "\r"
       when '\t';   "\t"
       when '\\\\'; "\\"
+      when "\\#{@param}"; "#{@param}"
       end
     }
     value
@@ -545,6 +546,7 @@ private
     value.gsub!(%r/\r/, '\r')
     value.gsub!(%r/\t/, '\t')
     value.gsub!(%r/\0/, '\0')
+    value.gsub!(%r/#{Regexp.escape(@param)}/, "\\#{@param}")
     value
   end
 

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -488,5 +488,28 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal '1', ini_file['nonce']['one']
     assert_equal '2', ini_file['nonce']['two']
   end
+
+  def test_round_trip_with_value_including_parameter
+    ini_file = IniFile.new(:filename => 'test/data/tmp.ini')
+    ini_file['foo'] = {
+      'bar' => '= baz'
+    }
+    ini_file.write
+
+    ini_file = IniFile.load('test/data/tmp.ini')
+    assert_equal '= baz', ini_file['foo']['bar']
+
+    FileUtils.rm_rf "test/data/tmp.ini"
+
+    ini_file = IniFile.new(:filename => 'test/data/tmp.ini')
+    ini_file['foo'] = {
+      'bar' => '== baz'
+    }
+    ini_file.write
+
+    ini_file = IniFile.load('test/data/tmp.ini')
+    assert_equal '== baz', ini_file['foo']['bar']
+
+  end
 end
 


### PR DESCRIPTION
I am using an inifile format to put some gem-esque version restrictions, a bit like:

```
[production]
web-api = ">= 1.4"
```

which reads OK, but if you try and write it out, it fails to quote or escape, which then fails to be read.

The commit I've written escapes the equals sign (wikipedia seemed to say that was a recognised escape for ini files), which also reads back in correctly.

Cheers,
Nick
