### PR TITLE
Unescaped section headers should be valid values

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -413,7 +413,15 @@ private
     until scanner.eos?
 
       # keep track of the current line for error messages
-      @_line = scanner.check(%r/\A.*$/) if scanner.bol?
+      if scanner.bol?
+        @_line = scanner.check(%r/\A.*$/)
+
+        # look for the start of a new section only when we are
+        # at the beginning of a line
+        if scanner.scan(%r/\A\s*\[([^\]]+)\]/)
+          @_section = @ini[scanner[1]]
+        end
+      end
 
       # look for escaped special characters \# \" etc
       if scanner.scan(%r/\\([\[\]#{@param}#{@comment}"])/)
@@ -441,10 +449,6 @@ private
         else
           parse_error
         end
-
-      # look for the start of a new section
-      elsif scanner.scan(%r/\A\s*\[([^\]]+)\]/)
-        @_section = @ini[scanner[1]]
 
       # otherwise scan and store characters till we hit the start of some
       # special section like a quote, newline, comment, etc.

--- a/test/data/section.ini
+++ b/test/data/section.ini
@@ -1,0 +1,4 @@
+; section headers can be values
+[section_one]
+one=[value]
+two=2

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -488,5 +488,13 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal '1', ini_file['nonce']['one']
     assert_equal '2', ini_file['nonce']['two']
   end
+
+  def test_unescaped_section_header_as_value
+    ini_file = IniFile.load('test/data/section.ini')
+
+    assert_equal %w[section_one], ini_file.sections
+    assert_equal '[value]', ini_file['section_one']['one']
+    assert_equal '2', ini_file['section_one']['two']
+  end
 end
 


### PR DESCRIPTION
``` ini
[section]
var=[value]
```

Here `[value]` should be a valid value and not another section header. This PR ensures we only scan for section headers at the beginning of a line.
