### PR TITLE
Parser refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ License
 -------
 
 MIT License
-Copyright (c) 2006 - 2012
+Copyright (c) 2006 - 2014
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -90,16 +90,13 @@ class IniFile
   #
   # opts - The default options Hash
   #        :filename - The filename as a String
-  #        :encoding - The encoding as a String (Ruby 1.9)
+  #        :encoding - The encoding as a String
   #
   # Returns this IniFile instance.
-  #
   def write( opts = {} )
     filename = opts.fetch(:filename, @filename)
     encoding = opts.fetch(:encoding, @encoding)
-    mode = (RUBY_VERSION >= '1.9' && encoding) ?
-         "w:#{encoding.to_s}" :
-         'w'
+    mode = encoding ? "w:#{encoding}" : "w"
 
     File.open(filename, mode) do |f|
       @ini.each do |section,hash|

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -3,12 +3,11 @@ require 'strscan'
 
 # This class represents the INI file and can be used to parse, modify,
 # and write INI files.
-#
 class IniFile
   include Enumerable
 
   class Error < StandardError; end
-  VERSION = '2.0.2'
+  VERSION = '3.0.0'
 
   # Public: Open an INI file and load the contents.
   #
@@ -134,7 +133,6 @@ class IniFile
   alias :restore :read
 
   # Returns this IniFile converted to a String.
-  #
   def to_s
     s = []
     @ini.each do |section,hash|
@@ -146,7 +144,6 @@ class IniFile
   end
 
   # Returns this IniFile converted to a Hash.
-  #
   def to_h
     @ini.dup
   end
@@ -157,7 +154,6 @@ class IniFile
   # other - The other IniFile.
   #
   # Returns a new IniFile.
-  #
   def merge( other )
     self.dup.merge!(other)
   end
@@ -169,7 +165,6 @@ class IniFile
   # other - The other IniFile.
   #
   # Returns this IniFile.
-  #
   def merge!( other )
     my_keys = @ini.keys
     other_keys =
@@ -202,7 +197,6 @@ class IniFile
   #   end
   #
   # Returns this IniFile.
-  #
   def each
     return unless block_given?
     @ini.each do |section,hash|
@@ -225,7 +219,6 @@ class IniFile
   #   end
   #
   # Returns this IniFile.
-  #
   def each_section
     return unless block_given?
     @ini.each_key {|section| yield section}
@@ -237,7 +230,6 @@ class IniFile
   # section - The section name as a String.
   #
   # Returns the deleted section Hash.
-  #
   def delete_section( section )
     @ini.delete section.to_s
   end
@@ -253,7 +245,6 @@ class IniFile
   #   #=> global section Hash
   #
   # Returns the Hash of parameter/value pairs for this section.
-  #
   def []( section )
     return nil if section.nil?
     @ini[section.to_s]
@@ -270,7 +261,6 @@ class IniFile
   #   #=> { 'gritty' => 'yes' }
   #
   # Returns the value Hash.
-  #
   def []=( section, value )
     @ini[section.to_s] = value
   end
@@ -287,7 +277,6 @@ class IniFile
   #
   # Return a Hash containing only those sections that match the given regular
   # expression.
-  #
   def match( regex )
     @ini.dup.delete_if { |section, _| section !~ regex }
   end
@@ -297,13 +286,11 @@ class IniFile
   # section - The section name as a String.
   #
   # Returns true if the section exists in the IniFile.
-  #
   def has_section?( section )
     @ini.has_key? section.to_s
   end
 
   # Returns an Array of section names contained in this IniFile.
-  #
   def sections
     @ini.keys
   end
@@ -312,7 +299,6 @@ class IniFile
   # the object will raise an error.
   #
   # Returns this IniFile.
-  #
   def freeze
     super
     @ini.each_value {|h| h.freeze}
@@ -324,7 +310,6 @@ class IniFile
   # marking each as tainted.
   #
   # Returns this IniFile.
-  #
   def taint
     super
     @ini.each_value {|h| h.taint}
@@ -337,7 +322,6 @@ class IniFile
   # original. The tainted state of the original is copied to the duplicate.
   #
   # Returns a new IniFile.
-  #
   def dup
     other = super
     other.instance_variable_set(:@ini, Hash.new {|h,k| h[k] = Hash.new})
@@ -352,7 +336,6 @@ class IniFile
   # to the duplicate.
   #
   # Returns a new IniFile.
-  #
   def clone
     other = dup
     other.freeze if self.frozen?
@@ -366,7 +349,6 @@ class IniFile
   # other - The other IniFile.
   #
   # Returns true if the INI files are equivalent and false if they differ.
-  #
   def eql?( other )
     return true if equal? other
     return false unless other.instance_of? self.class

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -17,7 +17,6 @@ class IniFile
   #            :comment   - String containing the comment character(s)
   #            :parameter - String used to separate parameter and value
   #            :encoding  - Encoding String for reading / writing (Ruby 1.9)
-  #            :escape    - Boolean used to control character escaping
   #            :default   - The String name of the default global section
   #
   # Examples
@@ -41,9 +40,6 @@ class IniFile
   # Get and set the encoding (Ruby 1.9)
   attr_accessor :encoding
 
-  # Enable or disable character escaping
-  attr_accessor :escape
-
   # Public: Create a new INI file from the given content String which
   # contains the INI file lines. If the content are omitted, then the
   # :filename option is used to read in the content of the INI file. If
@@ -55,7 +51,6 @@ class IniFile
   #           :comment   - String containing the comment character(s)
   #           :parameter - String used to separate parameter and value
   #           :encoding  - Encoding String for reading / writing (Ruby 1.9)
-  #           :escape    - Boolean used to control character escaping
   #           :default   - The String name of the default global section
   #           :filename  - The filename as a String
   #
@@ -81,7 +76,6 @@ class IniFile
     @comment  = opts.fetch(:comment, ';#')
     @param    = opts.fetch(:parameter, '=')
     @encoding = opts.fetch(:encoding, nil)
-    @escape   = opts.fetch(:escape, true)
     @default  = opts.fetch(:default, 'global')
     @filename = opts.fetch(:filename, nil)
 
@@ -519,8 +513,6 @@ private
   # Returns the unescaped value.
   #
   def unescape_value( value )
-    return value unless @escape
-
     value = value.to_s
     value.gsub!(%r/\\[0nrt\\]/) { |char|
       case char
@@ -541,8 +533,6 @@ private
   # Returns the escaped value.
   #
   def escape_value( value )
-    return value unless @escape
-
     value = value.to_s.dup
     value.gsub!(%r/\\([0nrt])/, '\\\\\1')
     value.gsub!(%r/\n/, '\n')

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -121,19 +121,17 @@ class IniFile
   #
   # opts - The default options Hash
   #        :filename - The filename as a String
-  #        :encoding - The encoding as a String (Ruby 1.9)
+  #        :encoding - The encoding as a String
   #
   # Returns this IniFile instance if the read was successful; nil is returned
   # if the file could not be read.
-  #
   def read( opts = {} )
     filename = opts.fetch(:filename, @filename)
     encoding = opts.fetch(:encoding, @encoding)
     return unless File.file? filename
 
-    mode = (RUBY_VERSION >= '1.9' && encoding) ?
-           "r:#{encoding.to_s}" : 'r'
-    File.open(filename, mode) { |fd| parse(fd.read) }
+    mode = encoding ? "r:#{encoding}" : "r"
+    File.open(filename, mode) { |fd| parse fd }
     self
   end
   alias :restore :read

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -490,7 +490,9 @@ class IniFile
       # unmatched open quote
       if leading_quote?
         error "Unmatched open quote"
-      elsif !value.nil?
+      elsif property && value
+        process_property
+      elsif value
         error
       end
     end

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -486,8 +486,13 @@ class IniFile
         end
       end
 
-      # check here if we have a dangling value ... means we have an unclosed
-      # continuation
+      # check here if we have a dangling value ... usually means we have an
+      # unmatched open quote
+      if leading_quote?
+        error "Unmatched open quote"
+      elsif !value.nil?
+        error
+      end
     end
 
     # Store the property/value pair in the currently active section. This

--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -379,12 +379,24 @@ class IniFile
     self
   end
 
+  # The IniFile::Parser has the responsibility of reading the contents of an
+  # .ini file and storing that information into a ruby Hash. The object being
+  # parsed must respond to `each_line` - this includes Strings and any IO
+  # object.
   class Parser
 
     attr_writer :section
     attr_accessor :property
     attr_accessor :value
 
+    # Create a new IniFile::Parser that can be used to parse the contents of
+    # an .ini file.
+    #
+    # hash    - The Hash where parsed information will be stored
+    # param   - String used to separate parameter and value
+    # comment - String containing the comment character(s)
+    # default - The String name of the default global section
+    #
     def initialize( hash, param, comment, default )
       @hash = hash
       @default = default
@@ -402,10 +414,20 @@ class IniFile
       @normal_value    = %r/\A(.*?)#{comment}/
     end
 
+    # Returns `true` if the current value starts with a leading double quote.
+    # Otherwise returns false.
     def leading_quote?
       value && value =~ %r/\A"/
     end
 
+    # Given a string, attempt to parse out a value from that string. This
+    # value might be continued on the following line. So this method returns
+    # `true` if it is expecting more data.
+    #
+    # string - String to parse
+    #
+    # Returns `true` if the next line is also part of the current value.
+    # Returns `fase` if the string contained a complete value.
     def parse_value( string )
       continuation = false
 
@@ -455,6 +477,10 @@ class IniFile
 
     # Parse the ini file contents. This will clear any values currently stored
     # in the ini hash.
+    #
+    # content - Any object that responds to `each_line`
+    #
+    # Returns nil.
     def parse( content )
       return unless content
 
@@ -495,6 +521,8 @@ class IniFile
       elsif value
         error
       end
+
+      nil
     end
 
     # Store the property/value pair in the currently active section. This

--- a/test/data/bad_2.ini
+++ b/test/data/bad_2.ini
@@ -1,0 +1,11 @@
+[section_one]
+one = 1
+two = 2
+
+[section_two]
+close-quote = "some text without
+a closing quote - should
+be interesting
+
+[section_three]
+wat = where is that closing quote?

--- a/test/data/comment.ini
+++ b/test/data/comment.ini
@@ -6,5 +6,5 @@ two = 2
 [section_two]  # you can comment here
 one = 42       # and even here!
 multi = 20 \   # and here, too
-+ 22 \= 42
++ 22 = 42
 

--- a/test/data/continuation.ini
+++ b/test/data/continuation.ini
@@ -1,0 +1,6 @@
+[section_one]
+one = 1
+two = 2
+
+[section_two]
+end-of-file = here is the last value \

--- a/test/data/good.ini
+++ b/test/data/good.ini
@@ -10,8 +10,8 @@ support
 ; comments should be ignored
 [section three]
 four   =4
-five=5
-six =6
+five=5   # comments can go here
+six =6   ; and here, too
 
 [section_four]
    [section_five]

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -497,5 +497,10 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal '[value]', ini_file['section_one']['one']
     assert_equal '2', ini_file['section_one']['two']
   end
+
+  def test_unmatched_quotes
+    # missing a closing quote should raise an error
+    assert_raise(IniFile::Error) { IniFile.load 'test/data/bad_2.ini' }
+  end
 end
 

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -502,5 +502,14 @@ class TestIniFile < Test::Unit::TestCase
     # missing a closing quote should raise an error
     assert_raise(IniFile::Error) { IniFile.load 'test/data/bad_2.ini' }
   end
+
+  def test_continuation_at_end_of_file
+    ini_file = IniFile.load('test/data/continuation.ini')
+
+    assert_equal '1', ini_file['section_one']['one']
+    assert_equal '2', ini_file['section_one']['two']
+
+    assert_equal 'here is the last value', ini_file['section_two']['end-of-file']
+  end
 end
 

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -511,5 +511,12 @@ class TestIniFile < Test::Unit::TestCase
 
     assert_equal 'here is the last value', ini_file['section_two']['end-of-file']
   end
+
+  def test_empty_comment_string
+    ini_file = IniFile.load('test/data/merge.ini', :comment => nil)
+
+    assert_equal '3', ini_file['section_one']['one']
+    assert_equal '5', ini_file['section_five']['five']
+  end
 end
 

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -461,16 +461,17 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal %Q{Escaping works\tinside quoted strings!}, escaped['quoted']
   end
 
+  # disabling escaping is no longer supported
   def test_value_escaping_disabled
     ini_file = IniFile.load('test/data/escape.ini', :escape => false)
     escaped = ini_file['escaped']
 
-    assert_equal %q{There is a tab\tcharacter in here somewhere}, escaped['tabs']
-    assert_equal %q{Who uses these anyways?\r}, escaped['carriage return']
-    assert_equal %q{Trust newline!\nAlways there when you need him.\nSplittin' those lines.}, escaped['newline']
-    assert_equal %Q{Who'd be silly enough to put\\0 a null character in the middle of a string? Stroustrup would not approve!}, escaped['null']
-    assert_equal %q{This string \\\\t contains \\\\n no \\\\r special \\\\0 characters!}, escaped['backslash']
-    assert_equal %q{Escaping works\tinside quoted strings!}, escaped['quoted']
+    assert_equal %Q{There is a tab\tcharacter in here somewhere}, escaped['tabs']
+    assert_equal %Q{Who uses these anyways?\r}, escaped['carriage return']
+    assert_equal %Q{Trust newline!\nAlways there when you need him.\nSplittin' those lines.}, escaped['newline']
+    assert_equal %Q{Who'd be silly enough to put\0 a null character in the middle of a string? Stroustrup would not approve!}, escaped['null']
+    assert_equal %q{This string \t contains \n no \r special \0 characters!}, escaped['backslash']
+    assert_equal %Q{Escaping works\tinside quoted strings!}, escaped['quoted']
   end
 
   def test_global_section


### PR DESCRIPTION
This PR is a complete refactoring of how we parse .ini files. The `StringScanner` class is no longer used. Instead we parse on a line by line basis. This enables us to read files one line at a time instead of loading the entire contents into a string and then parsing.

In order for this new parser to work, I've used [negative lookbehind](http://www.regular-expressions.info/lookaround.html#lookbehind) regular expressions. These are only available with Ruby 1.9 and above. This release of inifile will no longer work with Ruby 1.8.

I've also attempted to address a few of the open issues: 
closes #15
closes #16
closes #18
closes #26 

More changes to follow.
