### PR TITLE
Initialize by hash

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -77,8 +77,11 @@ class IniFile
 
     @ini = Hash.new {|h,k| h[k] = Hash.new}
 
-    if    content   then parse(content)
-    elsif @filename then read
+    content = opts.fetch(:content, nil) if content.nil?
+
+    if    content.is_a?(Hash) then merge!(content)
+    elsif content             then parse(content)
+    elsif @filename           then read
     end
   end
 
@@ -177,7 +180,7 @@ class IniFile
     end
 
     (other_keys - my_keys).each do |key|
-      @ini[key] = other[key]
+      @ini[key] = other[key] ? other[key].dup : {}
     end
 
     self

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -270,6 +270,35 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal '7 & 8', ini_file['section_five']['seven and eight']
   end
 
+  def test_initialize_from_hash
+    hash = {
+      'section one' => {
+        'foo' => 'bar',
+        'baz' => 'buz'
+      },
+      'colors' => {
+        'perrywinkle' => '7e6ff3',
+        'steelblue' => '4682b4'
+      },
+      'empty' => nil
+    }
+
+    ini_file = IniFile.new(:content => hash)
+    assert ini_file.has_section?('section one')
+    assert ini_file.has_section?('colors')
+    assert ini_file.has_section?('empty')
+
+    assert_equal %w[baz foo], ini_file['section one'].keys.sort
+    assert_equal 'bar', ini_file['section one']['foo']
+    assert_equal 'buz', ini_file['section one']['baz']
+
+    assert_equal %w[perrywinkle steelblue], ini_file['colors'].keys.sort
+    assert_equal '7e6ff3', ini_file['colors']['perrywinkle']
+    assert_equal '4682b4', ini_file['colors']['steelblue']
+
+    assert_empty ini_file['empty']
+  end
+
   def test_sections
     expected = [
       'section_one', 'section_two', 'section three',

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -456,6 +456,20 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal 1, @ini_file['section_one']['one']
   end
 
+  def test_merge_invalid_hash
+    bad_hash = { 'section_one' => [1, 2, 3, 4] }
+    assert_raise(IniFile::Error) { @ini_file.merge(bad_hash) }
+
+    bad_hash = { 'foo' => 'bar' }
+    assert_raise(IniFile::Error) { @ini_file.merge(bad_hash) }
+
+    not_a_hash = [['section_one', ['foo','bar'], ['baz', 'buz']]]
+    assert_raise(IniFile::Error) { @ini_file.merge(not_a_hash) }
+
+    ini_file = @ini_file.merge nil
+    assert ini_file.eql?(@ini_file)
+  end
+
   if RUBY_VERSION >= '1.9'
     def test_parse_encoding
       ini_file = IniFile.new(:filename => "test/data/browscap.ini", :encoding => 'ISO-8859-1')


### PR DESCRIPTION
These changes allow an IniFile to be created by passing in a Hash as the contents. To that end, the method signature of the constructor has been altered so that the `contents` are passed in only via the options hash:

``` ruby
IniFile.new(:content => hash)
```

closes #20 
