### PR TITLE
fixed typecast of values, as i.e. a value of 012 was parsed to 10

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -596,10 +596,17 @@ class IniFile
       when %r/\Afalse\z/i; false
       when %r/\A\s*\z/i;   nil
       else
-        Integer(value) rescue \
-        Float(value)   rescue \
-        unescape_value(value)
+        stripped_value = value.strip
+        if stripped_value =~ /^\d*\.\d+$/
+          Float(stripped_value)
+        elsif stripped_value =~ /^[^0]\d*$/
+          Integer(stripped_value)
+        else
+          unescape_value(value)
+        end
       end
+    rescue
+      unescape_value(value)
     end
 
     # Unescape special characters found in the value string. This will convert

--- a/test/data/typecast.ini
+++ b/test/data/typecast.ini
@@ -1,0 +1,7 @@
+[section_one]
+int1 = 146
+float1 = 0.35
+float2 = .634
+float3 = 234.646
+string1 = 00342
+string2 = 345.

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -557,5 +557,21 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal 3, ini_file['section_one']['one']
     assert_equal 5, ini_file['section_five']['five']
   end
+  
+  def test_integer_typecast
+    ini_file = IniFile.load('test/data/typecast.ini')
+    assert_equal 146, ini_file['section_one']['int1']
+    assert_equal "00342", ini_file['section_one']['string1']
+  end
+  
+  def test_float_typecast
+    ini_file = IniFile.load('test/data/typecast.ini')
+    assert_equal 0.35, ini_file['section_one']['float1']
+    assert_equal 0.634, ini_file['section_one']['float2']
+    assert_equal 234.646, ini_file['section_one']['float3']
+    assert_equal "345.", ini_file['section_one']['string2']
+  end
+  
+  
 end
 


### PR DESCRIPTION
Hi,

I was facing the issue that a value of 012 was parsed via `Integer("012")` and returned the integer value `10`. As an integer by definition may not have a leading zero, values starting with 0 will be parsed as either a float or a string.

Thanks for the good work
Lars
