### PR TITLE
support for single line switches in ini files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,23 @@ More information about INI files can be found on the [Wikipedia Page](http://en.
 
 ### Properties
 
-The basic element contained in an INI file is the property. Every property has
+A basic element contained in an INI file is the property. Every property has
 a name and a value, delimited by an equals sign *=*. The name appears to the
 left of the equals sign and the value to the right.
 
     name=value
+
+### Switches
+
+Switches are sometimes present in INI files to indicate whether a feature
+should be on or off.  Switches are made up by a single word on a line on its
+own.
+
+    name
+
+Switches are represented internally as an empty hash `{}` to avoid clashing
+with other values and are deactivated by removing the line from the file 
+completely.
 
 ### Sections
 
@@ -49,6 +61,7 @@ A typical INI file might look like this:
     # another comment
     var1 = baz
     var2 = shoodle
+    a_switch
 
 
 Implementation

--- a/test/data/switch.ini
+++ b/test/data/switch.ini
@@ -1,0 +1,3 @@
+[section_six]
+ switch_support
+

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -557,5 +557,19 @@ class TestIniFile < Test::Unit::TestCase
     assert_equal 3, ini_file['section_one']['one']
     assert_equal 5, ini_file['section_five']['five']
   end
+
+  def test_switch_support_read
+    ini_file = IniFile.load('test/data/switch.ini')
+
+    assert_equal({}, ini_file['section_six']['switch_support'])
+  end
+
+  def test_switch_support_write
+    ini_file = IniFile.new(:filename => "test/data/tmp.ini")
+    ini_file["foo"] = {"switch_support" => {}}
+    ini_file.save
+
+    assert File.read("test/data/tmp.ini") =~ /^switch_support$/
+  end
 end
 


### PR DESCRIPTION
This PR allows the library to support single line switches in INI files (Addresses #41)
## PR Highlights:
- single words made up of valid word characters are parsed as a _switch_
- switches parse as an empty hash `{}` and this can be used when saving the file back
- the empty hash was used instead of a simple Boolean value to avoid clashing with real values
- likewise `nil` clashes with the empty string `''`
- tests added
- documentation updated 
