### PR TITLE
added parameter to ignore line backslash line endings as line continuations

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -6,7 +6,7 @@ class IniFile
   include Enumerable
 
   class Error < StandardError; end
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 
   # Public: Open an INI file and load the contents.
   #
@@ -52,6 +52,7 @@ class IniFile
   #   :default   - The String name of the default global section
   #   :filename  - The filename as a String
   #   :slash_lc  - Use backslash as a line continuation
+  #   :separator - what to output between the key, operator, and value
   #
   # Examples
   #
@@ -68,13 +69,14 @@ class IniFile
   #   #=> an IniFile instance
   #
   def initialize( opts = {} )
-    @comment  = opts.fetch(:comment, ';#')
-    @param    = opts.fetch(:parameter, '=')
-    @encoding = opts.fetch(:encoding, nil)
-    @default  = opts.fetch(:default, 'global')
-    @filename = opts.fetch(:filename, nil)
-    @slash_lc = opts.fetch(:slash_lc, true)
-    content   = opts.fetch(:content, nil)
+    @comment   = opts.fetch(:comment, ';#')
+    @param     = opts.fetch(:parameter, '=')
+    @encoding  = opts.fetch(:encoding, nil)
+    @default   = opts.fetch(:default, 'global')
+    @filename  = opts.fetch(:filename, nil)
+    @slash_lc  = opts.fetch(:slash_lc, true)
+    @separator = opts.fetch(:separator, ' ')
+    content    = opts.fetch(:content, nil)
 
     @ini = Hash.new {|h,k| h[k] = Hash.new}
 
@@ -101,7 +103,7 @@ class IniFile
     File.open(filename, mode) do |f|
       @ini.each do |section,hash|
         f.puts "[#{section}]"
-        hash.each {|param,val| f.puts "#{param} #{@param} #{escape_value val}"}
+        hash.each {|param,val| f.puts "#{param}#{@separator}#{@param}#{@separator}#{escape_value val}"}
         f.puts
       end
     end
@@ -138,7 +140,7 @@ class IniFile
     s = []
     @ini.each do |section,hash|
       s << "[#{section}]"
-      hash.each {|param,val| s << "#{param} #{@param} #{escape_value val}"}
+      hash.each {|param,val| s << "#{param}#{@separator}#{@param}#{@separator}#{escape_value val}"}
       s << ""
     end
     s.join("\n")

--- a/test/data/line_continuation.ini
+++ b/test/data/line_continuation.ini
@@ -1,0 +1,13 @@
+; this test file demonstrates escape sequences supported by IniFile
+[normal]
+foo = http://en.wikipedia.org/wiki/Foobar
+
+[escaped]
+tabs = There is a tab\tcharacter in here somewhere
+carriage return = Who uses these anyways?\r
+newline = Trust newline!\nAlways there when you need him.\nSplittin' those lines.
+null = Who'd be silly enough to put\0 a null character in the middle of a string?
+line_continuation = C:\Temp\path\
+backslash = This string \\t contains \\n no \\r special \\0 characters!
+quoted = "Escaping works\tinside quoted strings!"
+

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -51,6 +51,10 @@ class TestIniFile < Test::Unit::TestCase
     ini_file = IniFile.load 'test/data/param.ini', :parameter => ':'
     assert_instance_of IniFile, ini_file
 
+    # check that backslash line continuation can be ignored by option
+    ini_file = IniFile.load 'test/data/line_continuation.ini', :slash_lc => false
+    assert_equal ini_file["escaped"]["line_continuation"], "C:\\Temp\\path\\"
+
     # make sure we error out on files with bad lines
     assert_raise(IniFile::Error) {IniFile.load 'test/data/bad_1.ini'}
   end


### PR DESCRIPTION
Hi,

I have INI files on windows platforms that regularly end with backslashes where values are folder paths - eg:

[general]
Logpath=C:\Temp\path\\
Logformat=name_something

This is currently treated as a line continuation, and read into the inifile instance as the value "C:\Temp\pathLogformat=name_something". To get around this i would have to escape the trailing backslash, which breaks my application.

In this PR I've added a new parameter "slash_lc" that accepts true/false and defaults to true (current behaviour). A false value allows my scenario above to work.

Example to use:
IniFile.load 'test/data/line_continuation.ini', :slash_lc => false

Thanks,
nicko