### PR TITLE
Support a force_array option to keep multiple values around

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -50,6 +50,7 @@ class IniFile
   #   :encoding  - Encoding String for reading / writing
   #   :default   - The String name of the default global section
   #   :filename  - The filename as a String
+  #   :force_array  - Keep all values with same key in an array
   #
   # Examples
   #
@@ -71,6 +72,7 @@ class IniFile
     @encoding = opts.fetch(:encoding, nil)
     @default  = opts.fetch(:default, 'global')
     @filename = opts.fetch(:filename, nil)
+    @force_array = opts.fetch(:force_array, nil)
     content   = opts.fetch(:content, nil)
 
     @ini = Hash.new {|h,k| h[k] = Hash.new}
@@ -98,7 +100,15 @@ class IniFile
     File.open(filename, mode) do |f|
       @ini.each do |section,hash|
         f.puts "[#{section}]"
-        hash.each {|param,val| f.puts "#{param} #{@param} #{escape_value val}"}
+        hash.each do |param,val|
+          if !val.is_a?(Array) || !@force_array
+            f.puts "#{param} #{@param} #{escape_value val}"
+          else
+            val.each do |subval|
+              f.puts "#{param} #{@param} #{escape_value subval}"
+            end
+          end
+        end
         f.puts
       end
     end
@@ -396,7 +406,7 @@ class IniFile
   #
   # Returns this IniFile.
   def parse( content )
-    parser = Parser.new(@ini, @param, @comment, @default)
+    parser = Parser.new(@ini, @param, @comment, @default, @force_array)
     parser.parse(content)
     self
   end
@@ -419,9 +429,10 @@ class IniFile
     # comment - String containing the comment character(s)
     # default - The String name of the default global section
     #
-    def initialize( hash, param, comment, default )
+    def initialize( hash, param, comment, default, force_array)
       @hash = hash
       @default = default
+      @force_array = force_array
 
       comment = comment.to_s.empty? ? "\\z" : "\\s*(?:[#{comment}].*)?\\z"
 
@@ -557,7 +568,13 @@ class IniFile
 
       self.value = $1 if value =~ %r/\A"(.*)(?<!\\)"\z/m
 
-      section[property] = typecast(value)
+      if section[property].nil? || !@force_array
+        section[property] = typecast(value)
+      elsif section[property].is_a?(Array)
+        section[property] << typecast(value)
+      else
+        section[property] = [section[property], typecast(value)]
+      end
 
       self.property = nil
       self.value = nil

--- a/test/data/force_array.ini
+++ b/test/data/force_array.ini
@@ -1,0 +1,5 @@
+[section_one]
+one = 1
+two = 2
+two = zinga
+two = "new foils"

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -559,3 +559,25 @@ class TestIniFile < Test::Unit::TestCase
   end
 end
 
+class TestCustomIniFile < Test::Unit::TestCase
+
+  def setup
+    FileUtils.rm_rf "test/data/tmp.ini"
+    FileUtils.cp    "test/data/good.ini", "test/data/tmp.ini"
+  end
+
+  def test_force_array
+    ini_file = IniFile.load('test/data/force_array.ini', force_array: true)
+    assert_equal 1, ini_file['section_one']['one']
+    assert_equal [2, "zinga", 'new foils'], ini_file['section_one']['two']
+
+    tmp = 'test/data/tmp.ini'
+    File.delete tmp if Kernel.test(?f, tmp)
+
+    ini_file.save(:filename => tmp)
+
+    lines = IO.readlines(tmp).map(&:chomp).keep_if{|x| x.size > 0}
+    assert_equal 5, lines.size
+    assert_equal ["[section_one]", "one = 1", "two = 2", "two = zinga", "two = new foils"], lines
+  end
+end


### PR DESCRIPTION
See the section called "The fix" in
http://engineering.pivotal.io/post/git-push-instead-of/
for a sample use case in an .ini file (in this case
.gitconfig recognizes multiple keyed values in a section)

See issue https://github.com/TwP/inifile/issues/49