### PR TITLE
Remove taintedness as it was removed in Ruby 3.2

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -323,17 +323,6 @@ class IniFile
     self
   end
 
-  # Public: Mark this IniFile as tainted -- this will traverse each section
-  # marking each as tainted.
-  #
-  # Returns this IniFile.
-  def taint
-    super
-    @ini.each_value {|h| h.taint}
-    @ini.taint
-    self
-  end
-
   # Public: Produces a duplicate of this IniFile. The duplicate is independent
   # of the original -- i.e. the duplicate can be modified without changing the
   # original. The tainted state of the original is copied to the duplicate.
@@ -343,13 +332,12 @@ class IniFile
     other = super
     other.instance_variable_set(:@ini, Hash.new {|h,k| h[k] = Hash.new})
     @ini.each_pair {|s,h| other[s].merge! h}
-    other.taint if self.tainted?
     other
   end
 
   # Public: Produces a duplicate of this IniFile. The duplicate is independent
   # of the original -- i.e. the duplicate can be modified without changing the
-  # original. The tainted state and the frozen state of the original is copied
+  # original. The frozen state of the original is copied
   # to the duplicate.
   #
   # Returns a new IniFile.


### PR DESCRIPTION
Merging inifiles does not work because in dup it attempts to taint which is no longer available in 3.2.