### PR TITLE
Remove taint methods

### DIFF
--- a/lib/inifile.rb
+++ b/lib/inifile.rb
@@ -323,34 +323,21 @@ class IniFile
     self
   end
 
-  # Public: Mark this IniFile as tainted -- this will traverse each section
-  # marking each as tainted.
-  #
-  # Returns this IniFile.
-  def taint
-    super
-    @ini.each_value {|h| h.taint}
-    @ini.taint
-    self
-  end
-
   # Public: Produces a duplicate of this IniFile. The duplicate is independent
   # of the original -- i.e. the duplicate can be modified without changing the
-  # original. The tainted state of the original is copied to the duplicate.
+  # original.
   #
   # Returns a new IniFile.
   def dup
     other = super
     other.instance_variable_set(:@ini, Hash.new {|h,k| h[k] = Hash.new})
     @ini.each_pair {|s,h| other[s].merge! h}
-    other.taint if self.tainted?
     other
   end
 
   # Public: Produces a duplicate of this IniFile. The duplicate is independent
   # of the original -- i.e. the duplicate can be modified without changing the
-  # original. The tainted state and the frozen state of the original is copied
-  # to the duplicate.
+  # original. The frozen state of the original is copied to the duplicate.
   #
   # Returns a new IniFile.
   def clone

--- a/test/test_inifile.rb
+++ b/test/test_inifile.rb
@@ -58,26 +58,17 @@ class TestIniFile < Test::Unit::TestCase
   def test_clone
     clone = @ini_file.clone
     assert_equal @ini_file, clone
-    assert !clone.tainted?
     assert !clone.frozen?
 
     # the clone should be completely independent of the original
     clone['new_section']['one'] = 1
     assert_not_equal @ini_file, clone
 
-    # the tainted state is copied to clones
-    @ini_file.taint
-    assert @ini_file.tainted?
-
-    clone = @ini_file.clone
-    assert clone.tainted?
-
     # the frozen state is also copied to clones
     @ini_file.freeze
     assert @ini_file.frozen?
 
     clone = @ini_file.clone
-    assert clone.tainted?
     assert clone.frozen?
   end
 
@@ -94,26 +85,17 @@ class TestIniFile < Test::Unit::TestCase
   def test_dup
     dup = @ini_file.dup
     assert_equal @ini_file, dup
-    assert !dup.tainted?
     assert !dup.frozen?
 
     # the duplicate should be completely independent of the original
     dup['new_section']['one'] = 1
     assert_not_equal @ini_file, dup
 
-    # the tainted state is copied to duplicates
-    @ini_file.taint
-    assert @ini_file.tainted?
-
-    dup = @ini_file.dup
-    assert dup.tainted?
-
     # the frozen state, however, is not
     @ini_file.freeze
     assert @ini_file.frozen?
 
     dup = @ini_file.dup
-    assert dup.tainted?
     assert !dup.frozen?
   end
 
@@ -309,20 +291,6 @@ class TestIniFile < Test::Unit::TestCase
 
     ini_file = IniFile.new(:filename => 'temp.ini')
     assert_equal [], ini_file.sections
-  end
-
-  def test_taint
-    assert_equal false, @ini_file.tainted?
-    @ini_file.each_section do |s|
-      assert_equal false, @ini_file[s].tainted?
-    end
-
-    @ini_file.taint
-
-    assert_equal true, @ini_file.tainted?
-    @ini_file.each_section do |s|
-      assert_equal true, @ini_file[s].tainted?
-    end
   end
 
   def test_write


### PR DESCRIPTION
Ruby has been gradually phasing out taint methods since Ruby 2.7, removing them entirely in Ruby 3.2[1].

This commit removes all taint methods.

[1] https://bugs.ruby-lang.org/issues/16131